### PR TITLE
Update urlschemes

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -67,7 +67,7 @@ function shuffle (a) {
 
 // load sites in new background tabs
 function loadSites (e) {
-  let urlschemes = ['http', 'https', 'file', 'view-source'];
+  let urlschemes = ['http', 'https', 'chrome', 'file', 'view-source'];
   let urls = txtArea.value.split(/\r\n?|\n/g);
   let lazyloading = lazyLoadCheckbox.checked;
   let random = randomCheckbox.checked;

--- a/popup.js
+++ b/popup.js
@@ -85,7 +85,8 @@ function loadSites (e) {
       if (
         lazyloading &&
         theurl.split(':')[0] !== 'view-source' &&
-        theurl.split(':')[0] !== 'file'
+        theurl.split(':')[0] !== 'file' &&
+        theurl.split(':')[0] !== 'chrome'
       ) {
         chrome.tabs.create({
           url: chrome.extension.getURL('lazyloading.html#') + theurl,

--- a/popup.js
+++ b/popup.js
@@ -67,7 +67,7 @@ function shuffle (a) {
 
 // load sites in new background tabs
 function loadSites (e) {
-  let urlschemes = ['http', 'https', 'chrome', 'file', 'view-source'];
+  let urlschemes = ['http', 'https', 'chrome', 'chrome-extension', 'file', 'view-source'];
   let urls = txtArea.value.split(/\r\n?|\n/g);
   let lazyloading = lazyLoadCheckbox.checked;
   let random = randomCheckbox.checked;


### PR DESCRIPTION
Additional urlschemes:
- Support "chrome://" URLs.
- Support "chrome-extension://" URLs.
- Fix "chrome://" URLs never load when `lazyLoadCheckbox.checked == true`.

PS: Merry Christmas.