### PR TITLE
Update urlschemes and fix bug

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -67,7 +67,7 @@ function shuffle (a) {
 
 // load sites in new background tabs
 function loadSites (e) {
-  let urlschemes = ['http', 'https', 'file', 'view-source'];
+  let urlschemes = ['http', 'https', 'chrome', 'chrome-extension', 'file', 'view-source'];
   let urls = txtArea.value.split(/\r\n?|\n/g);
   let lazyloading = lazyLoadCheckbox.checked;
   let random = randomCheckbox.checked;
@@ -85,7 +85,8 @@ function loadSites (e) {
       if (
         lazyloading &&
         theurl.split(':')[0] !== 'view-source' &&
-        theurl.split(':')[0] !== 'file'
+        theurl.split(':')[0] !== 'file' &&
+        theurl.split(':')[0] !== 'chrome'
       ) {
         chrome.tabs.create({
           url: chrome.extension.getURL('lazyloading.html#') + theurl,


### PR DESCRIPTION
New:
- Support "chrome://" URLs
- Support "chrome-extension://" URLs
- Fix "chrome://" URLs never load when `lazyLoadCheckbox` is checked

PS: Merry Christmas!