### PR TITLE
Feature: Ignore duplicate URLs (optionally)

### DIFF
--- a/src/browseraction.html
+++ b/src/browseraction.html
@@ -26,6 +26,9 @@
               >will open <span id="tabcount-number">0</span> new
               <span id="tabcount-tab-label">tabs</span></span
             >
+            <span id="tabcount-ignored">
+              (<span id="tabcount-ignored-number">0</span> ignored)
+            </span>
           </abbr>
         </span>
       </section>
@@ -45,6 +48,10 @@
         <label class="checkbox"
           ><input type="checkbox" id="reverse" tabindex="4" /> Load in reverse
           order</label
+        >
+        <label class="checkbox"
+          ><input type="checkbox" id="ignoreDuplicates" tabindex="5" /> Ignore duplicate URLs
+          </label
         >
       </section>
       <section>

--- a/src/browseraction/index.test.ts
+++ b/src/browseraction/index.test.ts
@@ -48,6 +48,7 @@ describe('test browser action', () => {
     expect(uiDef.lazyLoadCheckbox).toBeTruthy();
     expect(uiDef.randomCheckbox).toBeTruthy();
     expect(uiDef.reverseCheckbox).toBeTruthy();
+    expect(uiDef.ignoreDuplicatesCheckbox).toBeTruthy();
     expect(uiDef.preserveCheckbox).toBeTruthy();
     expect(uiDef.openButton).toBeTruthy();
     expect(uiDef.extractButton).toBeTruthy();
@@ -61,6 +62,7 @@ describe('test browser action', () => {
     expect(uiDef.lazyLoadCheckbox.checked).toBe(false);
     expect(uiDef.randomCheckbox.checked).toBe(false);
     expect(uiDef.reverseCheckbox.checked).toBe(false);
+    expect(uiDef.ignoreDuplicatesCheckbox.checked).toBe(false);
     expect(uiDef.preserveCheckbox.checked).toBe(false);
   });
 
@@ -73,6 +75,7 @@ describe('test browser action', () => {
     uiDef.lazyLoadCheckbox.click();
     uiDef.randomCheckbox.click();
     uiDef.reverseCheckbox.click();
+    uiDef.ignoreDuplicatesCheckbox.click();
     uiDef.preserveCheckbox.click();
 
     uiDef = getUIDef();
@@ -80,6 +83,7 @@ describe('test browser action', () => {
     expect(uiDef.lazyLoadCheckbox.checked).toBe(true);
     expect(uiDef.randomCheckbox.checked).toBe(true);
     expect(uiDef.reverseCheckbox.checked).toBe(true);
+    expect(uiDef.ignoreDuplicatesCheckbox.checked).toBe(true);
     expect(uiDef.preserveCheckbox.checked).toBe(true);
 
     document.body.innerHTML = BODY_HTML;
@@ -89,6 +93,7 @@ describe('test browser action', () => {
     expect(uiDef.lazyLoadCheckbox.checked).toBe(false);
     expect(uiDef.randomCheckbox.checked).toBe(false);
     expect(uiDef.reverseCheckbox.checked).toBe(false);
+    expect(uiDef.ignoreDuplicatesCheckbox.checked).toBe(false);
     expect(uiDef.preserveCheckbox.checked).toBe(false);
 
     await init();
@@ -97,7 +102,8 @@ describe('test browser action', () => {
     expect(uiDef.txtArea.value).toBe('foobar');
     expect(uiDef.lazyLoadCheckbox.checked).toBe(true);
     expect(uiDef.randomCheckbox.checked).toBe(true);
-    expect(uiDef.randomCheckbox.checked).toBe(true);
+    expect(uiDef.reverseCheckbox.checked).toBe(true);
+    expect(uiDef.ignoreDuplicatesCheckbox.checked).toBe(true);
     expect(uiDef.preserveCheckbox.checked).toBe(true);
   });
 
@@ -110,6 +116,7 @@ describe('test browser action', () => {
     expect(uiDef.txtArea.value).toBe('https://test.de');
     expect(uiDef.lazyLoadCheckbox.checked).toBe(false);
     expect(uiDef.randomCheckbox.checked).toBe(false);
+    expect(uiDef.ignoreDuplicatesCheckbox.checked).toBe(false);
     expect(uiDef.preserveCheckbox.checked).toBe(true);
   });
 
@@ -144,26 +151,31 @@ describe('test browser action', () => {
     expect(options.txt).toBe('');
     expect(options.lazyload).toBe(false);
     expect(options.random).toBe(false);
+    expect(options.ignoreDuplicates).toBe(false);
     expect(options.preserve).toBe(false);
 
     uiDef.lazyLoadCheckbox.click();
     uiDef.randomCheckbox.click();
+    uiDef.ignoreDuplicatesCheckbox.click();
     uiDef.preserveCheckbox.click();
 
     options = await getStoredOptions();
     expect(options.txt).toBe('');
     expect(options.lazyload).toBe(true);
     expect(options.random).toBe(true);
+    expect(options.ignoreDuplicates).toBe(true);
     expect(options.preserve).toBe(true);
 
     uiDef.lazyLoadCheckbox.click();
     uiDef.randomCheckbox.click();
+    uiDef.ignoreDuplicatesCheckbox.click();
     uiDef.preserveCheckbox.click();
 
     options = await getStoredOptions();
     expect(options.txt).toBe('');
     expect(options.lazyload).toBe(false);
     expect(options.random).toBe(false);
+    expect(options.ignoreDuplicates).toBe(false);
     expect(options.preserve).toBe(false);
   });
 
@@ -229,5 +241,13 @@ describe('test browser action', () => {
     expect(hasTabCount('3')).toBeTruthy();
     await sleep(UPDATE_TAB_COUNT_DEBOUNCE_TIME_MS);
     expect(hasTabCount('> 5000')).toBeTruthy();
+
+    uiDef.txtArea.value =
+      'https://test.de\n'.repeat(123).concat('\n\nhttps://spiegel.de\n    \nhttps://zeit.de\n\n   \n ');
+    uiDef.txtArea.dispatchEvent(new Event('input'));
+    expect(hasTabCount('> 5000')).toBeTruthy();
+    uiDef.ignoreDuplicatesCheckbox.checked = true;
+    await sleep(UPDATE_TAB_COUNT_DEBOUNCE_TIME_MS);
+    expect(hasTabCount('3')).toBeTruthy();
   });
 });

--- a/src/browseraction/index.ts
+++ b/src/browseraction/index.ts
@@ -21,11 +21,20 @@ const debouncedSaveUrlList = debounce(
 
 const updateTabCount = (ui: UIDef) => {
   let tabCount = '0';
+  let tabCountIgnored = '0';
   if (ui.txtArea.value) {
-    const lines = ui.txtArea.value.split(URL_LINE_SPLIT_REGEX);
+    let lines = ui.txtArea.value
+      .split(URL_LINE_SPLIT_REGEX)
+      .filter((line) => line.trim() !== '')
+      .map((line) => line.trim());
+    if (ui.ignoreDuplicatesCheckbox.checked) {
+      const tabCountOriginal = lines.length;
+      lines = lines.reduce((uniqueLines, line) => uniqueLines.includes(line) ? uniqueLines : [...uniqueLines, line], []);
+      tabCountIgnored = String(tabCountOriginal - lines.length);
+    }
     if (lines.length <= 5000) {
       // limit for performance reasons
-      tabCount = String(lines.filter((line) => line.trim() !== '').length);
+      tabCount = String(lines.length);
     } else {
       tabCount = '> 5000';
     }
@@ -34,6 +43,9 @@ const updateTabCount = (ui: UIDef) => {
   ui.tabCountNumber.textContent = tabCount;
   ui.tabCountTabLabel.textContent = tabCount === '1' ? 'tab' : 'tabs';
   ui.tabCount.style.visibility = tabCount === '0' ? 'hidden' : 'visible';
+
+  ui.tabCountIgnoredNumber.textContent = tabCountIgnored;
+  ui.tabCountIgnored.style.visibility = tabCountIgnored === '0' ? 'hidden' : 'visible';
 };
 const debouncedUpdateTabCount = debounce(
   updateTabCount,
@@ -49,6 +61,7 @@ export const init = async (): Promise<void> => {
   ui.lazyLoadCheckbox.checked = options.lazyload;
   ui.randomCheckbox.checked = options.random;
   ui.reverseCheckbox.checked = options.reverse;
+  ui.ignoreDuplicatesCheckbox.checked = options.ignoreDuplicates;
   ui.preserveCheckbox.checked = options.preserve;
 
   // add text input events
@@ -64,7 +77,8 @@ export const init = async (): Promise<void> => {
       ui.txtArea.value,
       ui.lazyLoadCheckbox.checked,
       ui.randomCheckbox.checked,
-      ui.reverseCheckbox.checked
+      ui.reverseCheckbox.checked,
+      ui.ignoreDuplicatesCheckbox.checked,
     );
   });
   ui.extractButton.addEventListener('click', () => {
@@ -92,6 +106,13 @@ export const init = async (): Promise<void> => {
       (<HTMLInputElement>event.target).checked
     )
   );
+  ui.ignoreDuplicatesCheckbox.addEventListener('change', (event) => {
+    debouncedUpdateTabCount(ui);
+    storeValue<boolean>(
+      StorageKey.ignoreDuplicates,
+      (<HTMLInputElement>event.target).checked
+    );
+  });
   ui.preserveCheckbox.addEventListener('change', (event) => {
     const isChecked = (<HTMLInputElement>event.target).checked;
     storeValue<boolean>(StorageKey.preserve, isChecked);

--- a/src/browseraction/load.test.ts
+++ b/src/browseraction/load.test.ts
@@ -16,7 +16,7 @@ describe('load tabs', () => {
   });
 
   test('load tabs in sequence', async () => {
-    loadSites(urlList, false, false, false);
+    loadSites(urlList, false, false, false, false);
 
     expect(browser.tabs.create).toHaveBeenNthCalledWith(1, {
       url: url1,
@@ -29,7 +29,7 @@ describe('load tabs', () => {
   });
 
   test('lazyload tabs in sequence', async () => {
-    loadSites(urlList, true, false, false);
+    loadSites(urlList, true, false, false, false);
 
     expect(browser.tabs.create).toHaveBeenNthCalledWith(1, {
       url: 'lazyloading.html#' + url1,
@@ -42,7 +42,7 @@ describe('load tabs', () => {
   });
 
   test('load tabs in random order', async () => {
-    loadSites(urlList, false, true, false);
+    loadSites(urlList, false, true, false, false);
 
     expect(browser.tabs.create).toHaveBeenCalledWith({
       url: url1,
@@ -55,7 +55,7 @@ describe('load tabs', () => {
   });
 
   test('lazyload tabs in random order', async () => {
-    loadSites(urlList, true, true, false);
+    loadSites(urlList, true, true, false, false);
 
     expect(browser.tabs.create).toHaveBeenCalledWith({
       url: 'lazyloading.html#' + url1,
@@ -68,7 +68,7 @@ describe('load tabs', () => {
   });
 
   test('load tabs in reverse order', async () => {
-    loadSites(urlList, false, false, true);
+    loadSites(urlList, false, false, true, false);
 
     expect(browser.tabs.create).toHaveBeenCalledWith({
       url: url2,
@@ -81,7 +81,7 @@ describe('load tabs', () => {
   });
 
   test('lazyload tabs in reverse order', async () => {
-    loadSites(urlList, true, false, true);
+    loadSites(urlList, true, false, true, false);
 
     expect(browser.tabs.create).toHaveBeenCalledWith({
       url: 'lazyloading.html#' + url2,
@@ -93,8 +93,36 @@ describe('load tabs', () => {
     });
   });
 
+  test('load tabs with duplicate URLs', async () => {
+    loadSites(urlList + '\n' + urlList, false, true, false, true);
+
+    expect(browser.tabs.create).toHaveBeenCalledTimes(2);
+    expect(browser.tabs.create).toHaveBeenCalledWith({
+      url: url1,
+      active: false,
+    });
+    expect(browser.tabs.create).toHaveBeenCalledWith({
+      url: url2,
+      active: false,
+    });
+  });
+
+  test('lazyload tabs with duplicate URLs', async () => {
+    loadSites(urlList + '\n' + urlList, true, true, false, true);
+
+    expect(browser.tabs.create).toHaveBeenCalledTimes(2);
+    expect(browser.tabs.create).toHaveBeenCalledWith({
+      url: 'lazyloading.html#' + url1,
+      active: false,
+    });
+    expect(browser.tabs.create).toHaveBeenCalledWith({
+      url: 'lazyloading.html#' + url2,
+      active: false,
+    });
+  });
+
   test('prepend http protocol if no protocol given', async () => {
-    loadSites('test.de', false, false, false);
+    loadSites('test.de', false, false, false, false);
 
     expect(browser.tabs.create).toHaveBeenNthCalledWith(1, {
       url: 'http://test.de',
@@ -105,6 +133,7 @@ describe('load tabs', () => {
   test('ignore lines containing only whitespace', async () => {
     loadSites(
       'http://test.de/f bar\n     \n' + url2 + '\n\n \t \n   ',
+      false,
       false,
       false,
       false
@@ -124,6 +153,7 @@ describe('load tabs', () => {
   test('handle different protocols', async () => {
     loadSites(
       'test.de\nhttp://test.de\nhttps://test.de\nfile://test.de\nview-source://test.de',
+      false,
       false,
       false,
       false

--- a/src/browseraction/load.ts
+++ b/src/browseraction/load.ts
@@ -26,7 +26,8 @@ export function loadSites(
   text: string,
   lazyloading: boolean,
   random: boolean,
-  reverse: boolean
+  reverse: boolean,
+  ignoreDuplicates: boolean
 ): void {
   const urlschemes = ['http', 'https', 'file', 'view-source'];
   let urls = text.split(URL_LINE_SPLIT_REGEX);
@@ -37,6 +38,10 @@ export function loadSites(
 
   if (random) {
     urls = shuffle(urls);
+  }
+
+  if (ignoreDuplicates) {
+    urls = urls.reduce((uniqueUrls, url) => uniqueUrls.includes(url) ? uniqueUrls : [...uniqueUrls, url], []);
   }
 
   for (let i = 0; i < urls.length; i++) {

--- a/src/browseraction/storage.ts
+++ b/src/browseraction/storage.ts
@@ -5,6 +5,7 @@ export enum StorageKey {
   lazyload = 'lazyload',
   random = 'random',
   reverse = 'reverse',
+  ignoreDuplicates = 'ignoreDuplicates',
   preserve = 'preserve',
 }
 
@@ -13,6 +14,7 @@ export interface StoredOptions {
   [StorageKey.lazyload]: boolean;
   [StorageKey.random]: boolean;
   [StorageKey.reverse]: boolean;
+  [StorageKey.ignoreDuplicates]: boolean;
   [StorageKey.preserve]: boolean;
 }
 
@@ -21,6 +23,7 @@ export async function getStoredOptions(): Promise<StoredOptions> {
   const lazyloadVal = await browser.storage.local.get(StorageKey.lazyload);
   const randomVal = await browser.storage.local.get(StorageKey.random);
   const reverseVal = await browser.storage.local.get(StorageKey.reverse);
+  const ignoreDuplicatesVal = await browser.storage.local.get(StorageKey.ignoreDuplicates);
   const preserveVal = await browser.storage.local.get(StorageKey.preserve);
 
   return {
@@ -28,6 +31,7 @@ export async function getStoredOptions(): Promise<StoredOptions> {
     lazyload: lazyloadVal?.lazyload || false,
     random: randomVal?.random || false,
     reverse: reverseVal?.reverse || false,
+    ignoreDuplicates: ignoreDuplicatesVal?.ignoreDuplicates || false,
     preserve: txtVal?.txt || preserveVal?.preserve || false,
   };
 }

--- a/src/browseraction/ui.ts
+++ b/src/browseraction/ui.ts
@@ -4,11 +4,14 @@ export interface UIDef {
   randomCheckbox: HTMLInputElement;
   reverseCheckbox: HTMLInputElement;
   preserveCheckbox: HTMLInputElement;
+  ignoreDuplicatesCheckbox: HTMLInputElement;
   openButton: HTMLInputElement;
   extractButton: HTMLInputElement;
   tabCount: HTMLSpanElement;
   tabCountNumber: HTMLSpanElement;
   tabCountTabLabel: HTMLSpanElement;
+  tabCountIgnored: HTMLSpanElement;
+  tabCountIgnoredNumber: HTMLSpanElement;
 }
 
 export function getUIDef(): UIDef {
@@ -18,14 +21,13 @@ export function getUIDef(): UIDef {
     randomCheckbox: document.getElementById('random') as HTMLInputElement,
     reverseCheckbox: document.getElementById('reverse') as HTMLInputElement,
     preserveCheckbox: document.getElementById('preserve') as HTMLInputElement,
+    ignoreDuplicatesCheckbox: document.getElementById('ignoreDuplicates') as HTMLInputElement,
     openButton: document.getElementById('open') as HTMLInputElement,
     extractButton: document.getElementById('extract') as HTMLInputElement,
     tabCount: document.getElementById('tabcount') as HTMLSpanElement,
-    tabCountNumber: document.getElementById(
-      'tabcount-number'
-    ) as HTMLSpanElement,
-    tabCountTabLabel: document.getElementById(
-      'tabcount-tab-label'
-    ) as HTMLSpanElement,
+    tabCountNumber: document.getElementById('tabcount-number') as HTMLSpanElement,
+    tabCountTabLabel: document.getElementById('tabcount-tab-label') as HTMLSpanElement,
+    tabCountIgnored: document.getElementById('tabcount-ignored') as HTMLSpanElement,
+    tabCountIgnoredNumber: document.getElementById('tabcount-ignored-number') as HTMLSpanElement
   };
 }


### PR DESCRIPTION
  - Adds an option to only open each unique URL once (ignore duplicates).
  - Extend 'tabcount' message to display amount of ignored URLs, if any.
  - Extend and adapt test suites to cover the new feature.
  - Trim whitespace around each line for improved matching of identical URLs.
  - Fixed minor bug I found in the index test suite.

See issue #58 

![image](https://user-images.githubusercontent.com/7607563/212479925-b0a7f3b0-2dcb-4432-8050-dcb36a5ddb7b.png)
