### PR TITLE
Add Firefox keyboard shortcut

### DIFF
--- a/src/manifest/firefox/manifest.json
+++ b/src/manifest/firefox/manifest.json
@@ -13,6 +13,13 @@
     "default_icon": "icon19.png",
     "default_popup": "browseraction.html"
   },
+  "commands": {
+    "_execute_browser_action": {
+      "suggested_key": {
+        "default": "Ctrl+M"
+      }
+    }
+  },
   "permissions": ["storage", "search", "contextualIdentities", "cookies"],
   "incognito": "spanning"
 }


### PR DESCRIPTION
Shortcut should not be available in chrome extension only.